### PR TITLE
Add RB_GC_GUARD to numo_pocketfft_fft to fix crash

### DIFF
--- a/ext/numo/pocketfft/pocketfftext.c
+++ b/ext/numo/pocketfft/pocketfftext.c
@@ -67,7 +67,6 @@ VALUE numo_pocketfft_fft(VALUE x_val, int is_forward)
   }
   
   RB_GC_GUARD(x_val);
-  RB_GC_GUARD(z_val);
 
   return z_val;
 }

--- a/ext/numo/pocketfft/pocketfftext.c
+++ b/ext/numo/pocketfft/pocketfftext.c
@@ -65,6 +65,9 @@ VALUE numo_pocketfft_fft(VALUE x_val, int is_forward)
     rb_funcall(z_val, rb_intern("free"), 0);
     return Qnil;
   }
+  
+  RB_GC_GUARD(x_val);
+  RB_GC_GUARD(z_val);
 
   return z_val;
 }


### PR DESCRIPTION
In https://github.com/yoshoku/numo-pocketfft/issues/3 I describe a crash I have been experiencing with numo-pocketfft.  When running RSpec tests in the mb-sound project, my FFT tests crash frequently, and occasionally return incorrect results.  These errors only happen at the `-O3` optimization level.  It appears this is due to Ruby's GC freeing either `x_val` or `z_val` before the function has finished, and other data being written in its place.

This fix uses the RB_GC_GUARD macro to make sure gcc preserves the `x_val` and `z_val` `VALUE`s in stack or registers so that the GC knows they are still in use.

See https://ruby-doc.org/core-2.7.1/doc/extension_rdoc.html#label-Appendix+E.+RB_GC_GUARD+to+protect+from+premature+GC

## Testing

To test the fix I ran `rspec` in a loop in the `fft` branch of the `mb-sound` project, as well as the reproducing script in https://github.com/yoshoku/numo-pocketfft/issues/3.  Before this change, tests would crash frequently.  After this change, tests ran without issue for many iterations.